### PR TITLE
added quick guard in DatePicker constructor

### DIFF
--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -13,14 +13,15 @@ class DatePicker extends Component {
 
   constructor (props) {
     super(props);
-
     const { availabilities } = this.props;
-    const days = _.groupBy(availabilities, date => moment(date).format('YYYY-MM-DD'));
-    const dates = _.keys(days);
-    const availableTimes = days[_.first(dates)].map(date => moment(date).format('HH:mm'));
-
+    let availableTimes
+    if (availabilities) {
+      const days = _.groupBy(availabilities, date => moment(date).format('YYYY-MM-DD'));
+      const dates = _.keys(days);
+      availableTimes = days[_.first(dates)].map(date => moment(date).format('HH:mm'));
+    }
     this.state = {
-      'availableTimes': availableTimes
+      'availableTimes': availableTimes || []
     };
   }
 


### PR DESCRIPTION
it is a quick fixup... Of my white screen in my menu page

<img width="1004" alt="screen shot 2017-10-03 at 01 32 51" src="https://user-images.githubusercontent.com/3239692/31173527-2dab4a60-a908-11e7-886f-b7e9d2093cb6.png">

Apparently DatePicker bugs with not clear logged bugs. Origin of the bug has to deal with my restaurants queries that return a fetch with no restaurants.availabilities defined.

maybe because my coopcycle-web is not at the last updates, ie the surface api between the two apps have diverged at some point between the two versions, I don't know :).

So one more long term thing to do is to sync the production state of the coopcycle-web with the coopcyle-js in order to have always compatible impedance.

And also, here, at the component level, one best practice is to make the computation inside the Component that considers always also the case where arrays or object are undefined :).



